### PR TITLE
feat(nexsock-protocol-core): Add core protocol components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,6 +2027,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "nexsock-protocol-core"
+version = "1.0.0-7"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "binrw",
+ "bytes",
+ "cfg-if",
+ "derive_more",
+ "futures",
+ "mlua",
+ "paste",
+ "savefile",
+ "serde",
+ "sqlx",
+ "thiserror 2.0.11",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "nexsock-utils"
 version = "1.0.0-7"
 dependencies = [

--- a/nexsock-protocol-core/Cargo.toml
+++ b/nexsock-protocol-core/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "nexsock-protocol-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+binrw = { version = "0.14" }
+tokio = { version = "1", features = ["full", "io-util"] }
+thiserror = "2.0"
+anyhow = "1.0"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+serde = { version = "1.0", features = ["derive"] }
+sqlx = { workspace = true }
+bincode = { workspace = true }
+derive_more.workspace = true
+paste = "1.0"
+futures = "0.3.19"
+
+savefile = { workspace = true, optional = true }
+mlua = { workspace = true, optional = true }
+cfg-if = "1.0"
+bytes = "1.10.0"
+
+[features]
+default = ["tokio"]
+tokio = []

--- a/nexsock-protocol-core/src/error.rs
+++ b/nexsock-protocol-core/src/error.rs
@@ -1,0 +1,20 @@
+use thiserror::Error;
+
+pub type ProtocolResult<T> = Result<T, ProtocolError>;
+
+#[derive(Error, Debug)]
+pub enum ProtocolError {
+    #[error("Expected payload but did not find any")]
+    ExpectedPayload,
+    
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Serialization {
+        error: Box<dyn std::error::Error + Send + Sync>,
+    },
+    #[error(transparent)]
+    Deserialization {
+        error: Box<dyn std::error::Error + Send + Sync>,
+    }
+}

--- a/nexsock-protocol-core/src/frame.rs
+++ b/nexsock-protocol-core/src/frame.rs
@@ -1,0 +1,165 @@
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use std::io;
+use derive_more::{AsMut, AsRef, BitAnd, BitAndAssign, BitOr, BitOrAssign, Deref, DerefMut};
+
+/// Protocol frame flags
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, BitOr, BitAnd, BitAndAssign, BitOrAssign, Deref, DerefMut, AsRef, AsMut)]
+pub struct FrameFlags(pub u16);
+
+impl FrameFlags {
+    // Common flags - can be extended as needed
+    pub const NONE: Self = Self(0);
+    pub const HAS_PAYLOAD: Self = Self(1 << 0);
+    pub const COMPRESSED: Self = Self(1 << 1);
+    pub const ENCRYPTED: Self = Self(1 << 2);
+    pub const REQUIRES_ACK: Self = Self(1 << 3);
+
+    pub fn contains(self, other: Self) -> bool {
+        (self.0 & other.0) == other.0
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    pub fn as_u16(self) -> u16 {
+        self.0
+    }
+
+    pub fn from_u16(value: u16) -> Self {
+        Self(value)
+    }
+}
+
+/// Protocol frame structure - this is the wire format
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Frame {
+    /// Magic bytes for validation (always "NEX\0")
+    pub magic: [u8; 4],
+
+    /// Protocol version
+    pub version: u16,
+
+    /// Message type identifier
+    pub message_type: u16,
+
+    /// Sequence number for message ordering
+    pub sequence: u32,
+
+    /// Frame flags
+    pub flags: FrameFlags,
+
+    /// Message payload
+    pub payload: Bytes,
+}
+
+impl Frame {
+    /// The magic bytes used to identify this protocol
+    pub const MAGIC: [u8; 4] = *b"NEX\0";
+
+    /// Default protocol version
+    pub const DEFAULT_VERSION: u16 = 1;
+
+    /// Create a new frame
+    pub fn new(message_type: u16, sequence: u32, flags: FrameFlags, payload: Bytes) -> Self {
+        Self {
+            magic: Self::MAGIC,
+            version: Self::DEFAULT_VERSION,
+            message_type,
+            sequence,
+            flags,
+            payload,
+        }
+    }
+
+    /// Check if the frame has a payload
+    pub fn has_payload(&self) -> bool {
+        self.flags.contains(FrameFlags::HAS_PAYLOAD)
+    }
+
+    /// Get the header size
+    pub const fn header_size() -> usize {
+        4 + // magic
+        2 + // version
+        2 + // message_type
+        4 + // sequence
+        2   // flags
+    }
+
+    /// Encode the frame to bytes
+    pub fn encode(&self) -> io::Result<BytesMut> {
+        let payload_len = self.payload.len();
+        let total_len = Self::header_size() + 4 + payload_len; // +4 for payload length
+
+        let mut buf = BytesMut::with_capacity(total_len);
+
+        // Write header
+        buf.put_slice(&self.magic);
+        buf.put_u16(self.version);
+        buf.put_u16(self.message_type);
+        buf.put_u32(self.sequence);
+        buf.put_u16(self.flags.as_u16());
+
+        // Write payload length and payload
+        buf.put_u32(payload_len as u32);
+        if !self.payload.is_empty() {
+            buf.put_slice(&self.payload);
+        }
+
+        Ok(buf)
+    }
+
+    /// Decode a frame from bytes
+    pub fn decode(mut buf: Bytes) -> io::Result<Self> {
+        if buf.len() < Self::header_size() + 4 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Buffer too small for frame header",
+            ));
+        }
+
+        // Read magic bytes
+        let mut magic = [0u8; 4];
+        buf.copy_to_slice(&mut magic);
+
+        // Validate magic bytes
+        if magic != Self::MAGIC {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Invalid magic bytes",
+            ));
+        }
+
+        // Read header fields
+        let version = buf.get_u16();
+        let message_type = buf.get_u16();
+        let sequence = buf.get_u32();
+        let flags = FrameFlags::from_u16(buf.get_u16());
+
+        // Read payload length and payload
+        let payload_len = buf.get_u32() as usize;
+        if buf.len() < payload_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Buffer too small for payload",
+            ));
+        }
+
+        let payload = if payload_len > 0 {
+            let payload_buf = buf.slice(0..payload_len);
+            buf.advance(payload_len);
+            payload_buf
+        } else {
+            Bytes::new()
+        };
+
+        Ok(Self {
+            magic,
+            version,
+            message_type,
+            sequence,
+            flags,
+            payload,
+        })
+    }
+}

--- a/nexsock-protocol-core/src/handler.rs
+++ b/nexsock-protocol-core/src/handler.rs
@@ -1,0 +1,220 @@
+// src/nexsock-protocol/src/handler.rs
+use std::collections::HashMap;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::sync::Arc;
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use tokio::pin;
+use crate::prelude::*;
+
+/// A trait for extracting typed data from a request frame
+pub trait FromRequest: Sized {
+    type Error: Into<ProtocolError> + std::error::Error;
+
+    /// Extract and convert the payload into the concrete type
+    fn from_request(payload: Bytes) -> Result<Self, Self::Error>;
+}
+
+/// Default FromRequest implementation for BinaryMessage types
+impl<T: BinaryMessage> FromRequest for T {
+    type Error = ProtocolError;
+
+    fn from_request(payload: Bytes) -> Result<Self, Self::Error> {
+        Self::deserialize(payload)
+    }
+}
+
+/// A trait for handlers that process requests and return responses
+pub trait Handler<Req, Res> {
+    type Future: Future<Output = Result<Res, ProtocolError>>;
+
+    fn call(&self, request: Req) -> Self::Future;
+
+    /// Get the message type this handler processes
+    fn message_type(&self) -> u16;
+
+    /// Get the response message type
+    fn response_type(&self) -> u16;
+}
+
+/// Type alias for a function-based handler
+pub type HandlerFn<F, Req, Res> = HandlerFunc<F, Req, Res>;
+
+/// A wrapper for function-based handlers
+pub struct HandlerFunc<F, Req, Res> {
+    f: F,
+    req_type: u16,
+    res_type: u16,
+    _req: PhantomData<Req>,
+    _res: PhantomData<Res>,
+}
+
+impl<F, Req, Res, Fut> HandlerFunc<F, Req, Res>
+where
+    F: Fn(Req) -> Fut,
+    Req: BinaryMessage,
+    Res: BinaryMessage,
+    Fut: Future<Output = Result<Res, ProtocolError>>,
+{
+    pub fn new(f: F, req_type: u16, res_type: u16) -> Self {
+        Self {
+            f,
+            req_type,
+            res_type,
+            _req: PhantomData,
+            _res: PhantomData,
+        }
+    }
+}
+
+impl<F, Req, Res, Fut> Handler<Req, Res> for HandlerFunc<F, Req, Res>
+where
+    F: Fn(Req) -> Fut,
+    Req: BinaryMessage,
+    Res: BinaryMessage,
+    Fut: Future<Output = Result<Res, ProtocolError>>,
+{
+    type Future = Fut;
+
+    fn call(&self, request: Req) -> Self::Future {
+        (self.f)(request)
+    }
+
+    fn message_type(&self) -> u16 {
+        self.req_type
+    }
+
+    fn response_type(&self) -> u16 {
+        self.res_type
+    }
+}
+
+// First, let's create a type-erased version of FrameProcessFuture
+pub type BoxedFrameFuture<'a> = BoxFuture<'a, Result<Bytes, ProtocolError>> /*Pin<Box<dyn Future<Output = Result<Bytes, ProtocolError>> + Send + Unpin>>*/;
+
+/// A future that will process a frame and produce a response frame
+pub struct FrameProcessFuture<'a> {
+    future: BoxedFrameFuture<'a>,
+    response_type: u16,
+    sequence: u32,
+}
+
+impl<'a> Future for FrameProcessFuture<'a> {
+    type Output = Result<Frame, ProtocolError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
+        let response_type = self.response_type;
+        let sequence = self.sequence;
+
+        // Poll the boxed future
+        match Pin::new(&mut self.future).poll(cx) {
+            std::task::Poll::Ready(Ok(payload)) => std::task::Poll::Ready(Ok(Frame::new(
+                response_type,
+                sequence,
+                FrameFlags::HAS_PAYLOAD,
+                payload,
+            ))),
+            std::task::Poll::Ready(Err(err)) => std::task::Poll::Ready(Err(err)),
+            std::task::Poll::Pending => std::task::Poll::Pending,
+        }
+    }
+}
+
+// Then update the MessageRegistry to use this non-generic version
+pub struct MessageRegistry<'a> {
+    handlers: HashMap<u16, Box<dyn Fn(Bytes) -> Result<FrameProcessFuture<'a>, ProtocolError> + Send + Sync>>,
+}
+
+impl<'a> MessageRegistry<'a> {
+    pub fn new() -> Self {
+        Self {
+            handlers: HashMap::new(),
+        }
+    }
+    
+    // In your register method, box the future
+    pub fn register<H, Req, Res>(&mut self, handler: H) -> &mut Self
+    where
+        H: Handler<Req, Res> + Send + Sync + 'static,
+        Req: FromRequest,
+        Res: BinaryMessage,
+        H::Future: Future<Output = Result<Res, ProtocolError>> + Send + 'a,
+    {
+        let message_type = handler.message_type();
+        let response_type = handler.response_type();
+        let handler = Arc::new(handler);
+
+        let handler_fn = Box::new(move |payload: Bytes| -> Result<FrameProcessFuture, ProtocolError> {
+            // Extract the request type from the payload
+            let request = Req::from_request(payload).map_err(Into::into)?;
+
+            // Create a clone for the handler call
+            let inner_handler = handler.clone();
+
+            // Call the handler to get its future
+            let response_future = inner_handler.call(request);
+
+            // Box and type-erase the future
+            let boxed_future: BoxedFrameFuture = Box::pin(async move {
+                let response = response_future.await?;
+                response.serialize()
+            });
+
+            Ok(FrameProcessFuture {
+                future: boxed_future,
+                response_type,
+                sequence: 0, // Will be set when processing the frame
+            })
+        });
+
+        self.handlers.insert(message_type, handler_fn);
+        self
+    }
+
+    // The process_frame method can now return the non-generic FrameProcessFuture
+    pub fn process_frame(&self, frame: Frame) -> Result<FrameProcessFuture, ProtocolError> {
+        let message_type = frame.message_type;
+        let sequence = frame.sequence;
+
+        // Find a handler for this message type
+        let handler = self.handlers.get(&message_type).ok_or_else(|| {
+            ProtocolError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("No handler for message type: {}", message_type)
+            ))
+        })?;
+
+        // Process the frame with the handler
+        let mut future = handler(frame.payload)?;
+
+        // Set the sequence number from the original frame
+        future.sequence = sequence;
+
+        Ok(future)
+    }
+}
+
+/// Extension trait for easier handler registration
+pub trait HandlerExt<F, Req, Res, Fut>
+where
+    F: Fn(Req) -> Fut,
+    Req: BinaryMessage + FromRequest,
+    Res: BinaryMessage,
+    Fut: Future<Output = Result<Res, ProtocolError>>,
+{
+    fn handler(self, req_type: u16, res_type: u16) -> HandlerFunc<F, Req, Res>;
+}
+
+impl<F, Req, Res, Fut> HandlerExt<F, Req, Res, Fut> for F
+where
+    F: Fn(Req) -> Fut,
+    Req: BinaryMessage + FromRequest,
+    Res: BinaryMessage,
+    Fut: Future<Output = Result<Res, ProtocolError>>,
+{
+    fn handler(self, req_type: u16, res_type: u16) -> HandlerFunc<F, Req, Res> {
+        HandlerFunc::new(self, req_type, res_type)
+    }
+}

--- a/nexsock-protocol-core/src/lib.rs
+++ b/nexsock-protocol-core/src/lib.rs
@@ -1,0 +1,9 @@
+#![allow(async_fn_in_trait)]
+
+pub mod error;
+pub mod prelude;
+pub mod frame;
+pub mod traits;
+mod handler;
+pub mod stream_transport;
+mod test;

--- a/nexsock-protocol-core/src/prelude.rs
+++ b/nexsock-protocol-core/src/prelude.rs
@@ -1,0 +1,5 @@
+pub use crate::error::*;
+pub use crate::frame::*;
+pub use crate::traits::*;
+pub use crate::stream_transport::*;
+pub use crate::handler::*;

--- a/nexsock-protocol-core/src/stream_transport.rs
+++ b/nexsock-protocol-core/src/stream_transport.rs
@@ -1,0 +1,92 @@
+use crate::prelude::*;
+use bytes::{Buf, BytesMut};
+use std::io;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+pub use tokio_transport::*;
+
+pub struct StreamTransport<R, W> {
+    reader: R,
+    writer: W,
+}
+
+impl<R, W> StreamTransport<R, W>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    /// Create a new stream transport
+    pub fn new(reader: R, writer: W) -> Self {
+        Self { reader, writer }
+    }
+}
+
+impl<R, W> Transport for StreamTransport<R, W>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    async fn send_frame(&mut self, frame: Frame) -> io::Result<()> {
+        let encoded = frame.encode()?;
+        self.writer.write_all(&encoded).await?;
+        self.writer.flush().await?;
+        Ok(())
+    }
+
+    async fn receive_frame(&mut self) -> io::Result<Frame> {
+        let header_size = Frame::header_size();
+        let mut header_buf = BytesMut::with_capacity(header_size + 4);
+        header_buf.resize(header_size + 4, 0);
+
+        self.reader.read_exact(&mut header_buf).await?;
+        
+        let payload_len = (&header_buf[header_size..header_size+4]).get_u32_le() as usize;
+
+        if payload_len > 0 {
+            let mut payload_buf = BytesMut::with_capacity(payload_len);
+            payload_buf.resize(payload_len, 0);
+            self.reader.read_exact(&mut payload_buf).await?;
+            
+            header_buf.extend_from_slice(&payload_buf);
+            Frame::decode(header_buf.freeze())
+        } else {
+            Frame::decode(header_buf.freeze())
+        }
+    }
+}
+
+#[cfg(feature = "tokio")]
+pub mod tokio_transport {
+    //! Exposes convenience methods to convert tokio streams into a [`StreamTransport]
+    use cfg_if::cfg_if;
+
+    cfg_if! {
+        if #[cfg(unix)] {
+            use super::*;
+            use tokio::net::UnixStream as Stream;
+            use tokio::net::TcpStream;
+            
+            pub fn from_stream(stream: Stream) -> impl Transport {
+                let (read, write) = stream.into_split();
+                StreamTransport::new(read, write)
+            }
+            
+            pub fn from_tcp_stream(stream: TcpStream) -> impl Transport {
+                let (read, write) = stream.into_split();
+                StreamTransport::new(read, write)
+            }
+        } else {
+            use super::*;
+            use tokio::net::TcpStream;
+            
+            pub fn from_stream(stream: TcpStream) -> impl Transport {
+                let (read, write) = stream.into_split();
+                StreamTransport::new(read, write)
+            }
+            
+            /// Same thing as [from_stream] if not on a `UNIX` based system
+            pub fn from_tcp_stream(stream: TcpStream) -> impl Transport {
+                from_stream(stream)
+            }
+        }
+    }
+}

--- a/nexsock-protocol-core/src/test.rs
+++ b/nexsock-protocol-core/src/test.rs
@@ -1,0 +1,100 @@
+#![cfg(test)]
+
+use bincode::{Decode, Encode};
+use crate::error::ProtocolError;
+use crate::frame::Frame;
+use crate::prelude::*;
+
+#[derive(Encode, Decode, Default)]
+pub struct TestRequest {
+    id: i64,
+    name: String
+}
+
+impl Message for TestRequest {
+    fn message_type() -> u16 {
+        1
+    }
+
+    fn to_frame(&self, sequence: u32) -> Result<Frame, ProtocolError> {
+        let payload = self.serialize()?;
+        Ok(Frame::new(
+            Self::message_type(),
+            sequence,
+            FrameFlags::HAS_PAYLOAD,
+            payload,
+        ))
+    }
+
+    fn from_frame(frame: Frame) -> Result<Self, ProtocolError> {
+        if !frame.has_payload() {
+            return Err(ProtocolError::ExpectedPayload);
+        }
+        Self::deserialize(frame.payload)
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode, PartialEq)]
+pub struct TestResponse {
+    id: i64,
+    message: String,
+}
+
+impl Message for TestResponse {
+    fn message_type() -> u16 {
+        2
+    }
+
+    fn to_frame(&self, sequence: u32) -> Result<Frame, ProtocolError> {
+        let payload = self.serialize()?;
+        Ok(Frame::new(
+            Self::message_type(),
+            sequence,
+            FrameFlags::HAS_PAYLOAD,
+            payload,
+        ))
+    }
+
+    fn from_frame(frame: Frame) -> Result<Self, ProtocolError> {
+        if !frame.has_payload() {
+            return Err(ProtocolError::ExpectedPayload);
+        }
+        Self::deserialize(frame.payload)
+    }
+}
+
+async fn test_handler(req: TestRequest) -> Result<TestResponse, ProtocolError> {
+    Ok(TestResponse {
+        id: req.id,
+        message: format!("Hello {}", req.name),
+    })
+}
+
+#[tokio::test]
+async fn test() {
+    let mut registry = MessageRegistry::new();
+    
+    registry.register(test_handler.handler(TestRequest::message_type(), TestResponse::message_type()));
+
+    // Create a test request
+    let request = TestRequest {
+        id: 42,
+        name: "Test".to_string(),
+    };
+
+    // Serialize the request to a frame
+    let request_frame = request.to_frame(123).unwrap();
+
+    // Process the frame through the registry
+    let process_future = registry.process_frame(request_frame).unwrap();
+
+    // Await the future to get a response frame
+    let response_frame = process_future.await.unwrap();
+
+    // Deserialize the response frame
+    let response = TestResponse::from_frame(response_frame).unwrap();
+
+    // Verify the response
+    assert_eq!(response.id, 42);
+    assert_eq!(response.message, "Hello Test");
+}

--- a/nexsock-protocol-core/src/traits/handler.rs
+++ b/nexsock-protocol-core/src/traits/handler.rs
@@ -1,0 +1,9 @@
+/*use std::future::Future;
+use crate::prelude::*;
+
+pub trait Handler<Args>: Send + Sync + 'static
+where
+    Args: BinaryMessage,
+{
+    fn call(args: Args) -> impl Future<Output = ()> + Send; // TODO: update return type to be structured and also needs to be implemented for all async functions
+}*/

--- a/nexsock-protocol-core/src/traits/message.rs
+++ b/nexsock-protocol-core/src/traits/message.rs
@@ -1,0 +1,84 @@
+use bincode::{config, Decode, Encode};
+use bytes::Bytes;
+use crate::error::ProtocolError;
+use crate::frame::{Frame, FrameFlags};
+
+/// Trait for messages that can be sent over the protocol
+pub trait Message: Sized {
+    /// Get the message type
+    fn message_type() -> u16;
+
+    /// Convert the message to a frame
+    fn to_frame(&self, sequence: u32) -> Result<Frame, ProtocolError>;
+
+    /// Create a message from a frame
+    fn from_frame(frame: Frame) -> Result<Self, ProtocolError>;
+}
+
+/// Helper trait for messages with binary serialization
+pub trait BinaryMessage: Message {
+    /// Serialize the message to bytes
+    fn serialize(&self) -> Result<Bytes, ProtocolError>;
+
+    /// Deserialize a message from bytes
+    fn deserialize(bytes: Bytes) -> Result<Self, ProtocolError>;
+
+    /// Default implementation of to_frame for binary messages
+    fn default_to_frame(&self, sequence: u32) -> Result<Frame, ProtocolError> {
+        let payload = self.serialize()?;
+        let has_payload = !payload.is_empty();
+        let flags = if has_payload { FrameFlags::HAS_PAYLOAD } else { FrameFlags::NONE };
+
+        Ok(Frame::new(
+            Self::message_type(),
+            sequence,
+            flags,
+            payload,
+        ))
+    }
+
+    /// Default implementation of from_frame for binary messages
+    fn default_from_frame(frame: Frame) -> Result<Self, ProtocolError> {
+        if frame.has_payload() {
+            Self::deserialize(frame.payload)
+        } else {
+            Err(ProtocolError::ExpectedPayload)
+        }
+    }
+}
+
+/// Helper trait for messages using bincode serialization
+pub trait BincodeMessage: Message + Encode + Decode<()> {
+    /// Default serialization using bincode
+    fn bincode_serialize(&self) -> Result<Bytes, ProtocolError> {
+        let config = config::standard();
+        let result = bincode::encode_to_vec(self, config)
+            .map_err(|e| ProtocolError::Serialization {
+                error: Box::new(e),
+            })?;
+
+        Ok(Bytes::from(result))
+    }
+
+    /// Default deserialization using bincode
+    fn bincode_deserialize(bytes: Bytes) -> Result<Self, ProtocolError> {
+        let config = config::standard();
+        let (result, _) = bincode::decode_from_slice(bytes.as_ref(), config)
+            .map_err(|e| ProtocolError::Deserialization { error: Box::new(e) })?;
+
+        Ok(result)
+    }
+}
+
+impl<T: Message + Encode + Decode<()>> BincodeMessage for T {}
+
+/// Implement BinaryMessage for any type that implements BincodeMessage
+impl<T: BincodeMessage> BinaryMessage for T {
+    fn serialize(&self) -> Result<Bytes, ProtocolError> {
+        self.bincode_serialize()
+    }
+
+    fn deserialize(bytes: Bytes) -> Result<Self, ProtocolError> {
+        Self::bincode_deserialize(bytes)
+    }
+}

--- a/nexsock-protocol-core/src/traits/mod.rs
+++ b/nexsock-protocol-core/src/traits/mod.rs
@@ -1,0 +1,6 @@
+mod message;
+mod handler;
+mod transport;
+
+pub use message::*;
+pub use transport::*;

--- a/nexsock-protocol-core/src/traits/transport.rs
+++ b/nexsock-protocol-core/src/traits/transport.rs
@@ -1,0 +1,11 @@
+use std::io;
+pub use crate::prelude::*;
+
+/// Transport trait for sending and receiving frames
+pub trait Transport {
+    /// Send a frame over the transport
+    async fn send_frame(&mut self, frame: Frame) -> io::Result<()>;
+
+    /// Receive a frame from the transport
+    async fn receive_frame(&mut self) -> io::Result<Frame>;
+}


### PR DESCRIPTION
This commit introduces the core components of the Nexsock protocol,
including the `StreamTransport` implementation, the `Frame` struct, and
the `Message` trait. These changes lay the foundation for the protocol
implementation and enable the creation of a robust and extensible
networking solution.

The key changes are:

- Add the `StreamTransport` struct, which provides a convenient way to
  work with async read and write streams, handling the encoding and
  decoding of protocol frames.
- Implement the `Transport` trait for `StreamTransport`, allowing it to
  be used as a transport layer for the protocol.
- Add the `Frame` struct, which represents a single protocol frame,
  including the ability to encode and decode frames.
- Introduce the `Message` trait, which defines the interface for
  protocol messages, including the ability to serialize and deserialize
  message payloads.
- Add a set of core modules, including `error`, `prelude`, `frame`,
  `traits`, `handler`, and `stream_transport`.
- Provide a set of utility functions in the `tokio_transport` module to
  simplify the creation of `StreamTransport` instances from Tokio
  streams.

These changes lay the groundwork for the Nexsock protocol
implementation, enabling the development of higher-level protocol
features and functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new protocol core library that enables asynchronous communication using structured data frames, robust error handling, and flexible messaging interfaces.
  - Added asynchronous stream transport capabilities for efficient network communication and simplified integration via consolidated imports.
  - Expanded public interfaces with new traits to facilitate message serialization, deserialization, and processing.

- **Tests**
  - Implemented comprehensive tests to ensure reliable message handling, proper frame encoding/decoding, and seamless error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->